### PR TITLE
Clean up new "or else" functions.

### DIFF
--- a/src/ErrorTypes.jl
+++ b/src/ErrorTypes.jl
@@ -153,15 +153,6 @@ macro unwrap_t_or(expr, T, exec)
     end
 end
 
-macro unwrap_t_or_else(expr, T, exec)
-    return quote
-        local res = $(esc(expr))
-        isa(res, Result) || throw(TypeError(Symbol("@unwrap_or"), Result, res))
-        local data = res.x
-        data isa $(esc(T)) ? data.x : $(esc(exec))(data.x)
-    end
-end
-
 # Note: jldoctests crashes on this ATM, even if it works correctly.
 """
     @unwrap_or(expr, exec)
@@ -191,44 +182,12 @@ macro unwrap_or(expr, exec)
 end
 
 """
-    @unwrap_or_else(expr, exec)
-Evaluate `expr` to a `Result`. If `expr` is a error value, evaluate
-`exec(expr)` and return that. Else, return the wrapped ok value in `expr`
-# Examples
-```
-julia> safe_sqrt(x)::Result{Float64,Complex{Float64}} = x < zero(x) ? Err(sqrt(-x) * 1im) : Ok(sqrt(x));
-
-julia> function sum_abs(it)
-    sum = 0.0
-    for i in it
-        sum += @unwrap_or_else safe_sqrt(i) abs
-    end
-    sum
-end;
-
-julia> sum_abs([-4,-1,0,1,4])
-6.0
-```
-"""
-macro unwrap_or_else(expr, exec)
-    return :(@unwrap_t_or_else $(esc(expr)) Ok $(esc(exec)))
-end
-
-"""
     @unwrap_error_or(expr, exec)
 
 Same as `@unwrap_or`, but unwraps errors.
 """
 macro unwrap_error_or(expr, exec)
     return :(@unwrap_t_or $(esc(expr)) Err $(esc(exec)))
-end
-
-"""
-    @unwrap_error_or(expr, exec)
-Same as `@unwrap_or_else`, but unwraps errors.
-"""
-macro unwrap_error_or_else(expr, exec)
-    return :(@unwrap_t_or_else $(esc(expr)) Err $(esc(exec)))
 end
 
 @noinline throw_unwrap_err() = error("unwrap on unexpected type")
@@ -292,10 +251,13 @@ If `x` is an error value, return `v`. Else, unwrap `x` and return its content.
 unwrap_or(x::Result, v) = @unwrap_or x v
 
 """
-    unwrap_or_else(x::Result, f)
+    unwrap_or_else(f, x::Result)
 If `x` is an error value, return `f(unwrap_error(x))`. Else, unwrap `x` and return its content.
 """
-unwrap_or_else(x::Result, f) = @unwrap_or_else x f
+function unwrap_or_else(f, x::Result)
+    y = x.x
+    return y isa Ok ? y.x : f(y.x)
+end
 
 """
     unwrap_error_or(x::Result, v)
@@ -305,10 +267,13 @@ Like `unwrap_or`, but unwraps an error.
 unwrap_error_or(x::Result, v) = @unwrap_error_or x v
 
 """
-    unwrap_error_or(x::Result, v)
+    unwrap_error_or(f, x::Result)
 Like `unwrap_or_else`, but unwraps an error.
 """
-unwrap_error_or_else(x::Result, f) = @unwrap_error_or_else x f
+function unwrap_error_or_else(f, x::Result)
+    y = x.x
+    return y isa Err ? y.x : f(y.x)
+end
 
 """
     flatten(x::Option{Option{T}})
@@ -338,6 +303,6 @@ export Ok, Err, Result, Option,
     is_error, some, none,
     unwrap, unwrap_error, expect, expect_error,
     and_then, unwrap_or, unwrap_or_else, map_or, unwrap_error_or, unwrap_error_or_else,
-    flatten, base, @?, @unwrap_or, @unwrap_or_else, @unwrap_error_or, @unwrap_error_or_else
+    flatten, base, @?, @unwrap_or, @unwrap_error_or
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,10 +54,10 @@ using Test
     @test unwrap_or(Result{Int, Int}(Err(1)), 1 + 1) === 2
 
     # unwrap_or_else
-    @test unwrap_or_else(Result{Int, Float64}(Ok(5)), (_) -> 11) === 5
-    @test unwrap_or_else(Result{Nothing, Nothing}(Ok(nothing)), (_) -> 1) === nothing
-    @test unwrap_or_else(Result{String, Dict}(Err(Dict("a" => "b"))), d -> d["a"]) == "b"
-    @test unwrap_or_else(Result{Int, Int}(Err(1)), x -> x + 1) === 2
+    @test unwrap_or_else(_ -> 11, Result{Int, Float64}(Ok(5))) === 5
+    @test unwrap_or_else(_ -> 1, Result{Nothing, Nothing}(Ok(nothing))) === nothing
+    @test unwrap_or_else(d -> d["a"], Result{String, Dict}(Err(Dict("a" => "b")))) == "b"
+    @test unwrap_or_else(x -> x + 1, Result{Int, Int}(Err(1))) === 2
 
     # unwrap_error_or
     @test unwrap_error_or(Result{Integer, AbstractFloat}(Err(1.1)), 1.2) === 1.1
@@ -66,10 +66,10 @@ using Test
     @test unwrap_error_or(Result{Int, UInt}(Ok(55)), UInt(1)) === UInt(1)
 
     # unwrap_error_or_else
-    @test unwrap_error_or_else(Result{Integer, AbstractFloat}(Err(1.1)), (_) -> 1.2) === 1.1
-    @test unwrap_error_or_else(Result{UInt8, UInt8}(Err(0x00)), (_) -> Dict()) === 0x00
-    @test unwrap_error_or_else(Result{Dict, String}(Ok(Dict())), d -> length(keys(d))) === 0
-    @test unwrap_error_or_else(Result{Int, UInt}(Ok(55)), (i) -> UInt(i)) === UInt(55)
+    @test unwrap_error_or_else(_ -> 1.2, Result{Integer, AbstractFloat}(Err(1.1))) === 1.1
+    @test unwrap_error_or_else(Dict, Result{UInt8, UInt8}(Err(0x00))) === 0x00
+    @test unwrap_error_or_else(d -> length(keys(d)), Result{Dict, String}(Ok(Dict()))) === 0
+    @test unwrap_error_or_else(UInt, Result{Int, UInt}(Ok(55))) === UInt(55)
 
     # expect
     @test expect(Result{Nothing, Int}(Ok(nothing)), "foo") === nothing


### PR DESCRIPTION
* Move argument order to have the function as first argument, in order to support do-syntax, and conform with Julia style guide
* Remove the redundant macro forms. The macro form is useful when the alternative can be a keyword like `continue`, but the semantics here only allow a callable, so there is no benefit of a macro over a normal function.